### PR TITLE
Add Kempner SLURM Job Metrics Collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 These collectors are intended to be used with prometheus to ship stats.  Each collector collects data on a different aspect of slurm.  Feel free to add or update these collectors to suit your needs.
 
+### SlurmJobNodeCollector
+
+This collector monitors individual SLURM job states and node status. It tracks job states (RUNNING, PENDING, etc.) and node availability (UP/DOWN), providing detailed visibility into job execution and cluster health at the individual job and node level.
+
 ### SlurmSchedStatsCollector
 
 This collector is a prometheus version of this:

--- a/slurm_job_metrics_collector.py
+++ b/slurm_job_metrics_collector.py
@@ -1,0 +1,128 @@
+#!/usr/bin/python3.11
+
+"""
+slurm_job_metrics_collector.py
+Prometheus exporter for detailed SLURM job metrics.
+
+This script:
+- Periodically collects granular SLURM job and node data using scontrol, squeue, sacct, and sinfo commands.
+- Exposes these metrics in Prometheus format at http://localhost:9100/metrics.
+
+Usage:
+  pip install prometheus_client
+  python slurm_job_metrics_collector.py
+"""
+
+import sys, os
+import subprocess
+import time
+from os import path
+
+prefix = os.path.normpath(
+    os.path.join(os.path.abspath(os.path.dirname(__file__)))
+)
+external = os.path.join(prefix, 'external')
+sys.path = [prefix, external] + sys.path
+
+from prometheus_client.core import GaugeMetricFamily, REGISTRY
+from prometheus_client.registry import Collector
+from prometheus_client import start_http_server
+
+class SlurmJobNodeCollector(Collector):
+    def __init__(self):
+        pass
+
+    def collect(self):
+        try:
+            job_state = GaugeMetricFamily(
+                'slurm_job_state',
+                'SLURM job state (1=RUNNING, 0=other)',
+                labels=['job_id', 'state']
+            )
+            
+            scontrol = GaugeMetricFamily(
+                'slurm_scontrol_raw',
+                'Raw SLURM job information from scontrol show job',
+                labels=['job_id', 'scontrol_data']
+            )
+            
+            jobs_per_partition = GaugeMetricFamily(
+                'slurm_jobs_per_partition',
+                'Number of jobs per SLURM partition',
+                labels=['partition']
+            )
+            
+            node_status = GaugeMetricFamily(
+                'slurm_node_status',
+                'SLURM node status (1=up, 0=down)',
+                labels=['node', 'state']
+            )
+
+            # Collect job states and detailed info with ONE squeue call
+            # Get job ID, state, and partition all at once
+            job_output = self.run_cmd('squeue --noheader --format="%i %T %P"')
+            
+            partition_counts = {}
+            
+            for line in job_output.splitlines():
+                if line.strip():
+                    parts = line.strip().split()
+                    if len(parts) >= 3:
+                        job_id, state, partition = parts[0], parts[1], parts[2]
+                        
+                        # Add job state metric
+                        value = 1 if state == "RUNNING" else 0
+                        job_state.add_metric([job_id, state], value)
+                        
+                        # Count partitions
+                        partition_counts[partition] = partition_counts.get(partition, 0) + 1
+                        
+                        # Get raw scontrol data
+                        try:
+                            scontrol_data = self.run_cmd(f'scontrol show job {job_id}')
+                            cleaned_data = scontrol_data.replace('\n', ' ').replace('"', '\\"')
+                            scontrol.add_metric([job_id, cleaned_data], 1)
+                        except Exception as e:
+                            print(f"Error getting scontrol data for job {job_id}: {e}")
+                            scontrol.add_metric([job_id, "ERROR: scontrol failed"], 0)
+
+            # Add partition counts
+            for partition, count in partition_counts.items():
+                jobs_per_partition.add_metric([partition], count)
+
+            # Collect node statuses
+            sinfo_output = self.run_cmd('sinfo -Nh -o "%N %T"')
+            for line in sinfo_output.splitlines():
+                parts = line.strip().split()
+                if len(parts) >= 2:
+                    node, state = parts[0], parts[1]
+                    value = 1 if state.upper() == "UP" else 0
+                    node_status.add_metric([node, state], value)
+
+            yield job_state
+            yield scontrol
+            yield jobs_per_partition
+            yield node_status
+
+        except Exception as e:
+            print(f"Error in collect method: {e}")
+            return
+
+    def run_cmd(self, cmd):
+        result = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(f"Command failed: {cmd}\n{result.stderr}")
+        return result.stdout.strip()
+
+if __name__ == "__main__":
+    start_http_server(9100)
+    REGISTRY.register(SlurmJobNodeCollector())
+    
+    # For testing: run once and keep server alive for data dump
+    print("Collector started. Metrics available at http://localhost:9100/metrics")
+    print("For testing - keeping server alive for 1 hour to allow data collection")
+    time.sleep(3600)  # Keep alive for 1 hour, then exit
+    
+    # For production: uncomment the lines below and comment out the testing section above
+    # while True:
+    #     time.sleep(600)  # Collect metrics every 10 minutes

--- a/slurm_job_metrics_collector.py
+++ b/slurm_job_metrics_collector.py
@@ -8,9 +8,6 @@ This script:
 - Periodically collects granular SLURM job and node data using scontrol, squeue, sacct, and sinfo commands.
 - Exposes these metrics in Prometheus format at http://localhost:9100/metrics.
 
-Usage:
-  pip install prometheus_client
-  python slurm_job_metrics_collector.py
 """
 
 import sys, os
@@ -70,14 +67,14 @@ class SlurmJobNodeCollector(Collector):
                     if len(parts) >= 3:
                         job_id, state, partition = parts[0], parts[1], parts[2]
                         
-                        # Add job state metric
+                        # Add job state 
                         value = 1 if state == "RUNNING" else 0
                         job_state.add_metric([job_id, state], value)
                         
                         # Count partitions
                         partition_counts[partition] = partition_counts.get(partition, 0) + 1
                         
-                        # Get raw scontrol data
+                        # Add raw scontrol data
                         try:
                             scontrol_data = self.run_cmd(f'scontrol show job {job_id}')
                             cleaned_data = scontrol_data.replace('\n', ' ').replace('"', '\\"')
@@ -90,7 +87,7 @@ class SlurmJobNodeCollector(Collector):
             for partition, count in partition_counts.items():
                 jobs_per_partition.add_metric([partition], count)
 
-            # Collect node statuses
+            # Add node statuses
             sinfo_output = self.run_cmd('sinfo -Nh -o "%N %T"')
             for line in sinfo_output.splitlines():
                 parts = line.strip().split()

--- a/slurm_job_metrics_collector.py
+++ b/slurm_job_metrics_collector.py
@@ -67,7 +67,6 @@ class SlurmJobNodeCollector(Collector):
                 
         except Exception as e:
             print(f"Error collecting job data: {e}")
-            # Still continue to try node collection
 
         # Try to collect node status
         try:

--- a/slurm_kempner_job_metrics_collector.py
+++ b/slurm_kempner_job_metrics_collector.py
@@ -135,6 +135,6 @@ if __name__ == "__main__":
     
     print("Kempner job metrics collector started. Metrics available at http://localhost:9009/metrics")
     
-    # Collect metrics every 30 seconds for telegraf
+    # Collect metrics every 30 seconds 
     while True:
         time.sleep(30)

--- a/slurm_kempner_job_metrics_collector.py
+++ b/slurm_kempner_job_metrics_collector.py
@@ -126,18 +126,15 @@ class SlurmJobNodeCollector(Collector):
         yield node_status
 
     def run_cmd(self, cmd):
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
         return result.stdout.strip()
 
 if __name__ == "__main__":
     start_http_server(9009)
     REGISTRY.register(SlurmJobNodeCollector())
     
-    # For testing: run once and keep server alive for data dump
     print("Kempner job metrics collector started. Metrics available at http://localhost:9009/metrics")
-    print("For testing - keeping server alive for 1 hour to allow data collection")
-    time.sleep(3600)  # Keep alive for 1 hour, then exit
     
-    # For production: uncomment the lines below and comment out the testing section above
-    # while True:
-    #     time.sleep(600)  # Collect metrics every 10 minutes
+    # Collect metrics every 30 seconds for telegraf
+    while True:
+        time.sleep(30)

--- a/slurm_kempner_job_metrics_collector.py
+++ b/slurm_kempner_job_metrics_collector.py
@@ -58,7 +58,7 @@ class SlurmJobNodeCollector(Collector):
     def collect(self):
         job_state = GaugeMetricFamily('slurm_job_state', 'SLURM job state (1=RUNNING, 0=other)', labels=['job_id', 'state'])
         job_details = GaugeMetricFamily('slurm_job_details', 'Comprehensive SLURM job information from sacct', 
-                                      labels=['job_id', 'user', 'partition', 'account', 'state', 'tres_cpu', 'tres_mem', 'tres_gres', 'start_time', 'end_time', 'requeue', 'elapsed', 'alloc_tres', 'node_list', 'ncpus'])
+                                      labels=['job_id', 'user', 'partition', 'account', 'state', 'tres_cpu', 'tres_mem', 'tres_gres', 'start_time', 'end_time', 'elapsed', 'alloc_tres', 'node_list', 'ncpus'])
         jobs_per_partition = GaugeMetricFamily('slurm_jobs_per_partition', 'Number of jobs per SLURM partition', labels=['partition'])
         node_status = GaugeMetricFamily('slurm_node_status', 'SLURM node status (1=up, 0=down)', labels=['node', 'state'])
 
@@ -69,15 +69,15 @@ class SlurmJobNodeCollector(Collector):
             job_output = self.run_cmd(['timeout', '-s', '9', '60s', '/usr/bin/sacct', 
                                      '--parsable2', '--noheader', '--allusers', '-X',
                                      '--partition=' + kempner_partitions,
-                                     '--format=JobID,User,Partition,Account,State,AllocCPUS,ReqMem,ReqGRES,Start,End,Requeue,Elapsed,AllocTRES,NodeList,NCPUs',
+                                     '--format=JobID,User,Partition,Account,State,AllocCPUS,ReqMem,ReqTRES,Start,End,Elapsed,AllocTRES,NodeList,NCPUs',
                                      '--starttime=today'])
             partition_counts = {}
             
             for line in job_output.splitlines():
                 if line.strip():
                     parts = line.strip().split('|')  
-                    if len(parts) >= 15:
-                        job_id, user, partition, account, state, cpu, memory, gres, start_time, end_time, requeue, elapsed, alloc_tres, node_list, ncpus = parts[0:15]
+                    if len(parts) >= 14:
+                        job_id, user, partition, account, state, cpu, memory, tres, start_time, end_time, elapsed, alloc_tres, node_list, ncpus = parts[0:14]
                         
                         # Skip empty or invalid entries
                         if not job_id or not state or not partition:
@@ -87,11 +87,11 @@ class SlurmJobNodeCollector(Collector):
                         value = 1 if state == "RUNNING" else 0
                         job_state.add_metric([job_id, state], value)
                         
-                        # Add job details with the four new fields
+                        # Add job details 
                         job_details.add_metric([
                             job_id, user, partition, account, state, 
-                            cpu or "0", memory or "0", gres or "none", 
-                            start_time or "unknown", end_time or "unknown", requeue or "0",
+                            cpu or "0", memory or "0", tres or "none", 
+                            start_time or "unknown", end_time or "unknown",
                             elapsed or "0", alloc_tres or "none", node_list or "unknown", ncpus or "0"
                         ], 1)
                         
@@ -126,7 +126,7 @@ class SlurmJobNodeCollector(Collector):
         yield node_status
 
     def run_cmd(self, cmd):
-        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        result = subprocess.run(cmd, capture_output=True, text=True)
         return result.stdout.strip()
 
 if __name__ == "__main__":
@@ -141,5 +141,3 @@ if __name__ == "__main__":
     # For production: uncomment the lines below and comment out the testing section above
     # while True:
     #     time.sleep(600)  # Collect metrics every 10 minutes
-    
-    print("Kempner job metrics collector finished.")

--- a/slurm_kempner_job_metrics_collector.py
+++ b/slurm_kempner_job_metrics_collector.py
@@ -5,7 +5,7 @@ slurm_kempner_job_metrics_collector.py
 Prometheus exporter for detailed SLURM job metrics.
 
 This script:
-- Periodically collects granular SLURM job and node data using scontrol, squeue, sacct, and sinfo commands.
+- Periodically collects granular SLURM job and node data using scontrol, sacct, and sinfo commands.
 - Exposes these metrics in Prometheus format at http://localhost:9100/metrics.
 - Filters for Kempner partition jobs and nodes only (configurable)
 
@@ -28,7 +28,30 @@ from prometheus_client import start_http_server
 
 class SlurmJobNodeCollector(Collector):
     def __init__(self):
-        pass
+        # Fallback hardcoded list in case dynamic discovery fails
+        self.fallback_kempner_partitions = ['kempner', 'kempner_dev', 'kempner_h100', 'kempner_requeue']
+
+    # Get all partitions with 'kempner'
+    def get_kempner_partitions(self):
+        try:
+            output = self.run_cmd(['timeout', '-s', '9', '30s', '/usr/bin/sinfo', '-h', '-o', '%R'])
+            partitions = []
+            seen = set()
+            
+            for line in output.splitlines():
+                partition = line.strip()
+                if partition and 'kempner' in partition.lower() and partition not in seen:
+                    partitions.append(partition)
+                    seen.add(partition)
+            
+            if partitions:
+                return ','.join(partitions)
+            else:
+                return ','.join(self.fallback_kempner_partitions)
+                
+        except Exception as e:
+            print(f"Error discovering partitions, using fallback: {e}")
+            return ','.join(self.fallback_kempner_partitions)
 
     def collect(self):
         job_state = GaugeMetricFamily('slurm_job_state', 'SLURM job state (1=RUNNING, 0=other)', labels=['job_id', 'state'])
@@ -36,19 +59,24 @@ class SlurmJobNodeCollector(Collector):
         jobs_per_partition = GaugeMetricFamily('slurm_jobs_per_partition', 'Number of jobs per SLURM partition', labels=['partition'])
         node_status = GaugeMetricFamily('slurm_node_status', 'SLURM node status (1=up, 0=down)', labels=['node', 'state'])
 
-        # Run squeue only once - to get job list and states 
+        kempner_partitions = self.get_kempner_partitions()
+
+        # Get job data (job ID, state, and partition)
         try:
-            job_output = self.run_cmd(['timeout', '-s', '9', '60s', '/usr/bin/squeue', '--noheader', '--format=%i %T %P'])
+            job_output = self.run_cmd(['timeout', '-s', '9', '60s', '/usr/bin/sacct', 
+                                     '--parsable2', '--noheader', 
+                                     '--partition=' + kempner_partitions,
+                                     '--format=JobID,State,Partition'])
             partition_counts = {}
             
             for line in job_output.splitlines():
                 if line.strip():
-                    parts = line.strip().split()
+                    parts = line.strip().split('|')  
                     if len(parts) >= 3:
                         job_id, state, partition = parts[0], parts[1], parts[2]
                         
-                        # Only process Kempner partitions
-                        if 'kempner' not in partition.lower():
+                        # Skip empty or invalid entries
+                        if not job_id or not state or not partition:
                             continue
 
                         # Add job state 
@@ -73,18 +101,16 @@ class SlurmJobNodeCollector(Collector):
         except Exception as e:
             print(f"Error collecting job data: {e}")
 
-        # Try to collect node status
+        # Set node status
         try:
-            sinfo_output = self.run_cmd(['timeout', '-s', '9', '60s', '/usr/bin/sinfo', '-Nh', '-o', '%N %T %R'])
+            sinfo_output = self.run_cmd(['timeout', '-s', '9', '60s', '/usr/bin/sinfo', 
+                                       '-Nh', '-o', '%N %T %R', 
+                                       '-p', kempner_partitions])
             for line in sinfo_output.splitlines():
                 parts = line.strip().split()
                 if len(parts) >= 3:
                     node, state, partition = parts[0], parts[1], parts[2]
                     
-                    # Only process Kempner partitions
-                    if 'kempner' not in partition.lower():
-                        continue
-
                     value = 1 if state.upper() == "UP" else 0
                     node_status.add_metric([node, state], value)
         except Exception as e:


### PR DESCRIPTION
## Overview
This PR adds a new Prometheus collector that provides detailed, individual-level SLURM job and node metrics.  

Filtered to include Kempner partitions only - this is configurable.

## Features
- Individual job tracking: Job states with job_id labels
- Comprehensive job data: Complete job details from sacct for backend parsing
- Partition aggregation: Job counts per partition
- Node monitoring: Individual node status tracking

## Metrics Provided - Kempner Partitions Only
- slurm_job_state{job_id, state} - Job state tracking
- slurm_job_details{job_id, user, partition, account, state, tres_cpu, tres_mem, tres_gres, start_time, end_time, elapsed, - alloc_tres, node_list, ncpus} - Comprehensive job information from sacct
- slurm_jobs_per_partition{partition} - Partition job counts
- slurm_node_status{node, state} - Node status monitoring

## Implementation
- Uses 'sinfo' twice (get kempner partitions, get node status) and 'sacct' once (get job data)
- Exposes metrics on port 9009