### PR TITLE
Remove --starttime=today filter from sacct command

### DIFF
--- a/slurm_kempner_job_metrics_collector.py
+++ b/slurm_kempner_job_metrics_collector.py
@@ -69,8 +69,7 @@ class SlurmJobNodeCollector(Collector):
             job_output = self.run_cmd(['timeout', '-s', '9', '60s', '/usr/bin/sacct', 
                                      '--parsable2', '--noheader', '--allusers', '-X',
                                      '--partition=' + kempner_partitions,
-                                     '--format=JobID,JobIDRaw,User,Partition,Account,State,AllocCPUS,ReqMem,ReqTRES,Start,End,Elapsed,AllocTRES,NodeList,NCPUs,ReqCPUS,Submit,Eligible,Reason',
-                                     '--starttime=today'])
+                                     '--format=JobID,JobIDRaw,User,Partition,Account,State,AllocCPUS,ReqMem,ReqTRES,Start,End,Elapsed,AllocTRES,NodeList,NCPUs,ReqCPUS,Submit,Eligible,Reason'])
             partition_counts = {}
             
             for line in job_output.splitlines():


### PR DESCRIPTION
Remove '--starttime=today' filter from sacct command.  

This filter prevented our ability to track multi-day jobs.  For example, if a job started yesterday but completed today, we would not be able to track when the job completed.
