### PR TITLE
Fix midnight boundary bug - add sacct call in first 2 min after midnight

### DIFF
--- a/slurm_kempner_job_metrics_collector.py
+++ b/slurm_kempner_job_metrics_collector.py
@@ -17,6 +17,7 @@ import sys, os
 import subprocess
 import time
 from os import path
+from datetime import datetime, timedelta
 
 prefix = os.path.normpath(
     os.path.join(os.path.abspath(os.path.dirname(__file__)))
@@ -66,10 +67,27 @@ class SlurmJobNodeCollector(Collector):
 
         # Get job data from sacct 
         try:
-            job_output = self.run_cmd(['timeout', '-s', '9', '60s', '/usr/bin/sacct', 
+            sacct_format = 'JobID,JobIDRaw,User,Partition,Account,State,AllocCPUS,ReqMem,ReqTRES,Start,End,Elapsed,AllocTRES,NodeList,NCPUs,ReqCPUS,Submit,Eligible,Reason'
+            main_output = self.run_cmd(['timeout', '-s', '9', '60s', '/usr/bin/sacct', 
                                      '--parsable2', '--noheader', '--allusers', '-X',
                                      '--partition=' + kempner_partitions,
-                                     '--format=JobID,JobIDRaw,User,Partition,Account,State,AllocCPUS,ReqMem,ReqTRES,Start,End,Elapsed,AllocTRES,NodeList,NCPUs,ReqCPUS,Submit,Eligible,Reason'])
+                                     '--format=' + sacct_format])
+
+            # Supplemental sacct call for the first 2 minutes after midnight.
+            # Catches jobs whose terminal state (COMPLETED, CANCELLED, etc.) fell
+            # through the midnight boundary when sacct's default window resets.
+            now = datetime.now()
+            if now.hour == 0 and now.minute < 2:
+                yesterday = (now - timedelta(days=1)).strftime('%Y-%m-%dT23:58:00')
+                supplemental = self.run_cmd(['timeout', '-s', '9', '60s', '/usr/bin/sacct',
+                                           '--parsable2', '--noheader', '--allusers', '-X',
+                                           '--partition=' + kempner_partitions,
+                                           '--starttime=' + yesterday,
+                                           '--format=' + sacct_format])
+                if supplemental:
+                    main_output = main_output + '\n' + supplemental
+
+            job_output = main_output
             partition_counts = {}
             
             for line in job_output.splitlines():

--- a/slurm_kempner_job_metrics_collector.py
+++ b/slurm_kempner_job_metrics_collector.py
@@ -74,8 +74,6 @@ class SlurmJobNodeCollector(Collector):
                                      '--format=' + sacct_format])
 
             # Supplemental sacct call for the first 2 minutes after midnight.
-            # Catches jobs whose terminal state (COMPLETED, CANCELLED, etc.) fell
-            # through the midnight boundary when sacct's default window resets.
             now = datetime.now()
             if now.hour == 0 and now.minute < 2:
                 yesterday = (now - timedelta(days=1)).strftime('%Y-%m-%dT23:58:00')


### PR DESCRIPTION
**PROBLEM**

- The exporter doesn't catch terminal state changes between:
    - the last scrape before midnight, and
    - the first scrape after midnight (only retrieves data since 00:00:00 by default if there is no `starttime=` flag)
- Due to this 'midnight blindspot,' the dashboard currently shows a job as RUNNING, but that job ended right before midnight last night.

**Example Scenario**
- 23:59:35 -  last `sacct `exporter scrape before midnight (scrapes every 30 seconds)
- 23:59:40 -  job ended 
- 00:00:05 - `sacct `exporter scrapes data since 00:00:00 (default for sacct w/o a `--starttime` window) and misses that the job ended

**FIX**

- I added a supplemental sacct call to scrape updates around midnight.
- If it is between midnight and 00:02:00, a supplemental sacct scrape gets all job updates since 23:58:00 the day before.